### PR TITLE
Allowed quality:10 in GIF.setQuality()

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -66,7 +66,8 @@ export class Gif {
 			throw new MAGError('The quality needs to be a number')
 		if (quality <= 0)
 			throw new MAGError('The quality cannot be less than 0')
-		if (quality >= 10) throw new MAGError('Quality 10 is the max')
+		if (quality > 10) 
+			throw new MAGError('Quality 10 is the max')
 
 		this.quality = quality
 


### PR DESCRIPTION
Changed `>= 10` to `> 10` so that `10` would be a valid option